### PR TITLE
Add missing router annotations config

### DIFF
--- a/config/routes/annotations.yaml
+++ b/config/routes/annotations.yaml
@@ -1,0 +1,8 @@
+# config/routes/annotations.yaml
+controllers:
+    resource: ../../src/Controller/
+    type: annotation
+
+kernel:
+    resource: ../../src/Kernel.php
+    type: annotation


### PR DESCRIPTION
This allows displaying the default Route instead of 404 error